### PR TITLE
revert mongodb dep in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-mkdir": "~0.1.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-githooks": "~0.3.1",
-    "mongodb": "2.2.20"
+    "mongodb": "2.2.35"
   },
   "keywords": []
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "proxyquire": "0.5.1",
     "grunt-mkdir": "~0.1.1",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-githooks": "~0.3.1"
+    "grunt-githooks": "~0.3.1",
+    "mongodb": "2.2.20"
   },
   "keywords": []
 }


### PR DESCRIPTION
Reopen previous PR to include mongodb in devDependencies of package.json due mongodb is used by tests directly.