### PR TITLE
Split Docs and Unit Test into separate jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: node_js
-
 sudo: required
-
-node_js:
-  - "8"
-  - "10"
 
 branches:
   only:
@@ -13,18 +8,42 @@ branches:
 services:
   - docker
 
-install:
-  - npm install
+jobs:
+  include:
+    - stage: test
+      name: "Unit Tests: Node 8"
+      node_js: 8
 
-before_install:
-  - docker pull telefonicaiot/fiware-orion
-  - docker run --name mongodb -d mongo:3.4
-  - docker run --name orion -d --link mongodb:mongodb -p 10026:1026 telefonicaiot/fiware-orion -dbhost mongodb
+      before_install:
+        - docker pull telefonicaiot/fiware-orion
+        - docker run --name mongodb -d mongo:3.4
+        - docker run --name orion -d --link mongodb:mongodb -p 10026:1026 telefonicaiot/fiware-orion -dbhost mongodb
 
-before_script:
-  - npm run lint
-  - npm run lint:md
-  - npm run lint:text
+      before_script:
+        - npm run lint
 
-after_script:
-  - npm run test:coveralls
+      after_script:
+        - npm run test:coveralls
+
+    - stage: test
+      name: "Unit Tests: Node 10"
+      node_js: 10
+
+      before_install:
+        - docker pull telefonicaiot/fiware-orion
+        - docker run --name mongodb -d mongo:3.4
+        - docker run --name orion -d --link mongodb:mongodb -p 10026:1026 telefonicaiot/fiware-orion -dbhost mongodb
+
+      before_script:
+        - npm run lint
+
+      after_script:
+        - npm run test:coveralls
+
+    - stage: test
+      name: "Documentation Tests"
+      node_js: 10
+
+      script:
+        - npm run lint:md
+        - npm run lint:text

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "clean": "rm -rf package-lock.json && rm -rf node_modules && rm -rf coverage",
     "lint": "jshint lib/ --config .jshintrc && jshint test/ --config test/.jshintrc",
-    "lint:md": "remark 'README.md' docs",
+    "lint:md": "remark -f 'README.md' docs",
     "lint:text": "textlint 'README.md' 'docs/*.md' 'docs/**/*.md'",
     "prettier": "prettier --config .prettierrc.json --write ./**/**/*.js **/*.js *.js",
     "prettier:text": "prettier 'README.md' 'docs/*.md' 'docs/**/*.md' --no-config --tab-width 4 --print-width 120 --write --prose-wrap always",
@@ -81,6 +81,15 @@
     "*.yml": [
       "prettier --no-config --write",
       "git add"
+    ]
+  },
+  "remarkConfig": {
+    "settings": {
+      "bullet": "-",
+      "paddedTable": true
+    },
+    "plugins": [
+      "remark-preset-lint-recommended"
     ]
   }
 }


### PR DESCRIPTION
Tidying up the travis file to clarify where any failure occurs - previously an documentation issue would *error* the build rather than *fail* it.