### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,10 @@
 site_name: IoT Agent for Sigfox
 site_url: https://fiware-iotagent-sigfox.readthedocs.org
-repo_url: https://github.com/telefonicaid/sigfox-iotagent.git
+repo_url: https://github.com/telefonicaid/sigfox-iotagent
 site_description: IoT Agent for SigFox Documentation
 docs_dir: docs
 site_dir: html
+edit_uri: edit/master/docs/
 markdown_extensions: [toc, fenced_code]
 use_directory_urls: false
 theme: readthedocs


### PR DESCRIPTION
Adding the right config parameter, according to mkdocs instructions will fix documentation broken links:
https://www.mkdocs.org/user-guide/configuration/#edit_uri
The same fix has been applied successfully in other similar repositories:
telefonicaid/fiware-orion#3491
Also this must be changed:
Repo URL must be:
repo_url: https://github.com/telefonicaid/sigfox-iotagent
Instead of
repo_url: https://github.com/telefonicaid/sigfox-iotagent.git