### PR TITLE
Add PM2_ENABLED flag to Docker

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -191,7 +191,8 @@
        "ignore": [
           "mailto:*",
           "https://github.com/telefonicaid/sigfox-iotagent/blob/master/doc/roadmap.md",
-          "https://coveralls.io/**"
+          "https://coveralls.io/**",
+          "https://*.rtfd.io"
       ]
     }
   }

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,0 +1,1 @@
+- ADD PM2_ENABLED flag to Docker

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Information about how to use the IoT Agent can be found in the [User & Programme
 ## API
 
 Apiary reference for the Configuration API can be found
-[here](http://docs.telefonicaiotiotagents.apiary.io/#reference/configuration-api) More information about IoT Agents and
+[here](https://telefonicaiotiotagents.docs.apiary.io/#reference/configuration-api) More information about IoT Agents and
 their APIs can be found in the IoT Agent Library [documentation](https://iotagent-node-lib.rtfd.io/).
 
 ## Testing

--- a/docker/README.md
+++ b/docker/README.md
@@ -161,7 +161,7 @@ docker run --name iotagent -e PM2_ENABLED=true -d fiware/sigfox-iotagent
 
 Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
 your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
-Kubenetes)
+[Kubernetes](https://kubernetes.io/))
 
 ### Docker Secrets
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -150,6 +150,19 @@ COPY . /opt/iotasigfox/
 
 Full instructions can be found within the `Dockerfile` itself.
 
+### Using PM2
+
+The IoT Agent within the Docker image can be run encapsulated within the [pm2](http://pm2.keymetrics.io/) Process
+Manager by adding the `PM2_ENABLED` environment variable.
+
+```console
+docker run --name iotagent -e PM2_ENABLED=true -d fiware/sigfox-iotagent
+```
+
+Use of pm2 is **disabled** by default. It is unnecessary and counterproductive to add an additional process manager if
+your dockerized environment is already configured to restart Node.js processes whenever they exit (e.g. when using
+Kubenetes)
+
 ### Docker Secrets
 
 As an alternative to passing sensitive information via environment variables, `_FILE` may be appended to some sensitive

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,4 +65,12 @@ else
     fi
 fi
 
-pm2-runtime /opt/iotasigfox/bin/iotagent-sigfox
+if [[  -z "$PM2_ENABLED" ]]; then
+    echo "INFO: IoT Agent running standalone"
+    node /opt/iotasigfox/bin/iotagent-sigfox
+else
+    echo "***********************************************"
+    echo "INFO: IoT Agent encapsulated by pm2-runtime see https://pm2.io/doc/en/runtime/integration/docker/"
+    echo "***********************************************"
+    pm2-runtime /opt/iotasigfox/bin/iotagent-sigfox
+fi


### PR DESCRIPTION
This PR is a potential fix for https://github.com/telefonicaid/iotagent-node-lib/issues/790

* Update entrypoint to use/not use pm2
* Add `PM2_ENABLED` to Docker README
* Update CNR.