### PR TITLE
fix: use config variable for Sigfox port in unit tests

### DIFF
--- a/test/unit/deviceProvisioning-test.js
+++ b/test/unit/deviceProvisioning-test.js
@@ -79,7 +79,7 @@ describe('Device and configuration provisioning', function() {
             }
         };
         const dataOpts = {
-            url: 'http://localhost:17428/update',
+            url: 'http://localhost:' + config.sigfox.port + '/update',
             method: 'GET',
             qs: {
                 id: 'sigApp2',

--- a/test/unit/ngsi-communication-test.js
+++ b/test/unit/ngsi-communication-test.js
@@ -115,7 +115,7 @@ describe('Context Broker communication', function() {
 
     describe('When a new sigfox measure arrives to the IoT Agent', function() {
         const options = {
-            url: 'http://localhost:17428/update',
+            url: 'http://localhost:' + config.sigfox.port + '/update',
             method: 'GET',
             qs: {
                 id: 'sigApp1',
@@ -188,7 +188,7 @@ describe('Context Broker communication', function() {
 
     describe('When a new piece of data arrives for a unexistent device', function() {
         const options = {
-            url: 'http://localhost:17428/update',
+            url: 'http://localhost:' + config.sigfox.port + '/update',
             method: 'GET',
             qs: {
                 id: 'unexistentApp',

--- a/test/unit/plugin-config-test.js
+++ b/test/unit/plugin-config-test.js
@@ -59,7 +59,7 @@ describe('Plugin configuration test', function() {
             }
         };
         const dataOpts = {
-            url: 'http://localhost:17428/update',
+            url: 'http://localhost:' + config.sigfox.port + '/update',
             method: 'GET',
             qs: {
                 id: 'sigApp3',


### PR DESCRIPTION
In unit tests, use the port number configured in the test config, instead of the hardcoded default value.