### PR TITLE
doc: fix some typos and path to iotagent-sigfox

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ The Agent provides the following features:
 
 -   IoT Agent North Bound functionalities, as defined in the
     [IoT Agent Node.js library](https://github.com/telefonicaid/iotagent-node-lib).
--   A Sigfox endpoint listening for callbacks from the sigfox backend. Each piece of coming from the backend is
-    considered as a sepparate active attribute (as defined in the IoT Agents specification).
+-   A Sigfox endpoint listening for callbacks from the sigfox backend. Each piece of information coming from the backend
+    is considered as a separate active attribute (as defined in the IoT Agents specification).
 -   A Sigfox data parser that can be used to convert from the data format as defined in the callbacks to a JavaScript
     array.
 -   A testing tool to simulate the date coming from the device.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,8 +11,8 @@ order given. The development team will be doing their best to follow the propose
 in mind that plans to work on a given feature or task may be revised. All information is provided as a general
 guidelines only, and this section may be revised to provide newer information at any time.
 
-At the present moment, this compoment is in manteinance mode. Evolution will be driven by customer needs.
-Thus, there is no explicit description of short/medium/long term roadmap items, although you can have
-a look to the current list of issues [here](https://github.com/telefonicaid/sigfox-iotagent/issues).
+At the present moment, this compoment is in mantainance mode. Evolution will be driven by customer needs. Thus, there is
+no explicit description of short/medium/long term roadmap items, although you can have a look to the current list of
+issues [here](https://github.com/telefonicaid/sigfox-iotagent/issues).
 
 Please feel free to contact us if you wish to get involved in the implementation or influence the roadmap.

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -19,7 +19,7 @@ NOTE: this first version doesn't support Configuration provisioning, so each dev
 In order to start the agent, execute the following command from the root of the project:
 
 ```bash
-bin/iotagent
+bin/iotagent-sigfox
 ```
 
 ### Provisioning the device in the Agent
@@ -186,7 +186,7 @@ following values (expressed in decimal base):
 
 The project is managed using npm.
 
-For a list of available task, type
+For a list of available tasks, type
 
 ```bash
 npm run


### PR DESCRIPTION
Just to fix some small typos spotted in the docs.