### PR TITLE
chore: add context to log messages where missing for easier tracing

### DIFF
--- a/lib/iotagentCore.js
+++ b/lib/iotagentCore.js
@@ -32,16 +32,16 @@ const context = {
 const config = require('./configService');
 
 function updateConfigurationHandler(newConfiguration, callback) {
-    config.getLogger().error('Unsupported configuration update received');
+    config.getLogger().error(context, 'Unsupported configuration update received');
     callback();
 }
 
 function deviceProvisioningMiddleware(device, callback) {
-    config.getLogger().debug('device provisioning handler %j', device.internalAttributes);
+    config.getLogger().debug(context, 'device provisioning handler %j', device.internalAttributes);
     let mappingFound = false;
     if (device.internalAttributes) {
         for (let i = 0; i < device.internalAttributes.length; i++) {
-            config.getLogger().debug('device provisioning handler %s', device.internalAttributes[i]);
+            config.getLogger().debug(context, 'device provisioning handler %s', device.internalAttributes[i]);
             if (device.internalAttributes[i].mapping) {
                 mappingFound = true;
             }
@@ -50,7 +50,7 @@ function deviceProvisioningMiddleware(device, callback) {
             }
         }
         if (!mappingFound) {
-            config.getLogger().error('device provisioning mapping not found');
+            config.getLogger().error(context, 'device provisioning mapping not found');
             callback(new errors.DataMappingNotFound(device.type), device);
         }
     }


### PR DESCRIPTION
Add context where missing in the logs messages, for consistency with other logs, but also for easier tracing.