### PR TITLE
Docker Compose File Fix

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -61,7 +61,7 @@ services:
         container_name: db-mongo
         ports:
             - "27017:27017"
-        command: --bind_ip_all --smallfiles
+        command: --bind_ip_all
         volumes:
             - mongodb:/data
 


### PR DESCRIPTION
**Issue:**
`--smallfiles` flag was deprecated in MongoDB 4.2 as shown in the [changelog](https://docs.mongodb.com/manual/release-notes/4.2/), making the docker instance to crush.

**Action:**
removed the `--smallfiles` flag from the docker-compose file.