### PR TITLE
Create config.json

### DIFF
--- a/.github/fiware/config.json
+++ b/.github/fiware/config.json
@@ -1,0 +1,19 @@
+{
+    "enabler": "FIWARE IoT Agent for Sigfox",
+    "chapter": "iotagents",
+    "academy": "iot-agents/idas",
+    "readthedocs": "iotagent-sigfox",
+    "helpdesk": "",
+    "coveralls": "https://coveralls.io/github/telefonicaid/sigfox-iotagent",
+    "github": ["telefonicaid/sigfox-iotagent"],
+    "dockerregistry": ["hub.docker.com"],
+    "docker": ["telefonicaiot/sigfox-iotagent"],
+    "email": "iot_support@tid.es",
+    "status": "full",
+    "compose": "",
+    "exclude": [""],
+    "stackexchange": ["fiware+iot"],
+    "unit-test": "",
+    "smoke-test": "",
+    "dockerfile": "https://github.com/telefonicaid/sigfox-iotagent/blob/master/docker/Dockerfile"
+}


### PR DESCRIPTION
The FIWARE Foundation need a simple JSON file available in a standard location in each repo to be able to continue to make FIWARE Releases and improve the degree of cross-product integration testing that can occur. This change has been agreed by the TSC and has been added to the contribution requirements.

Please suggest or amend values where known.