### PR TITLE
Add graceful shutdown

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,3 +1,4 @@
 - Upgrade underscore dep from 1.8.3 to 1.12.1
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
+- FIX: Add graceful shutdown listening to SIGINT (#606)

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,4 +1,4 @@
 - Upgrade underscore dep from 1.8.3 to 1.12.1
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
-- FIX: Add graceful shutdown listening to SIGINT (#606)
+- FIX: Add graceful shutdown listening to SIGINT (#115)

--- a/docs/usermanual.md
+++ b/docs/usermanual.md
@@ -194,6 +194,15 @@ npm run
 
 The following sections show the available options in detail.
 
+### Start
+
+Runs a local version of the IoT Agent
+
+```bash
+# Use git-bash on Windows
+npm start
+```
+
 ### Testing
 
 [Mocha](https://mochajs.org/) Test Runner + [Should.js](https://shouldjs.github.io/) Assertion Library.

--- a/lib/sigfoxServer.js
+++ b/lib/sigfoxServer.js
@@ -101,11 +101,33 @@ function start(newConfig, callback) {
     iotServer.server.listen(iotServer.app.get('port'), iotServer.app.get('host'), callback);
 }
 
+/**
+ * Stop the current IoT Agent instance.
+ */
 function stop(callback) {
     config.getLogger().info(context, 'Stopping Sigfox server');
 
     iotServer.server.close(callback);
 }
+
+/**
+ * Shuts down the IoT Agent in a graceful manner
+ *
+ */
+function handleShutdown(signal) {
+    config.getLogger().fatal(context, 'Received %s, starting shutdown processs', signal);
+    stop((err) => {
+        if (err) {
+            config.getLogger().error(context, err);
+            return process.exit(1);
+        }
+        return process.exit(0);
+    });
+}
+
+process.on('SIGINT', handleShutdown);
+process.on('SIGTERM', handleShutdown);
+process.on('SIGHUP', handleShutdown);
 
 exports.start = start;
 exports.stop = stop;

--- a/lib/sigfoxServer.js
+++ b/lib/sigfoxServer.js
@@ -115,7 +115,7 @@ function stop(callback) {
  *
  */
 function handleShutdown(signal) {
-    config.getLogger().fatal(context, 'Received %s, starting shutdown processs', signal);
+    config.getLogger().info(context, 'Received %s, starting shutdown processs', signal);
     stop((err) => {
         if (err) {
             config.getLogger().error(context, err);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:text": "textlint 'README.md' 'docs/*.md' 'docs/**/*.md'",
     "prettier": "prettier --config .prettierrc.json --write '**/**/**/*.js' '**/**/*.js' '**/*.js' '*.js'",
     "prettier:text": "prettier 'README.md' 'docs/*.md' 'docs/**/*.md' --no-config --tab-width 4 --print-width 120 --write --prose-wrap always",
+    "start": "node ./bin/sigfox-iotagent",
     "test": "nyc --reporter=text mocha --recursive 'test/**/*.js' --reporter spec --timeout 3000 --ui bdd --exit --color true",
     "test:coverage": "nyc --reporter=lcov mocha -- --recursive 'test/**/*.js' --reporter spec --exit --color true",
     "test:coveralls": "npm run test:coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",


### PR DESCRIPTION
When a shutdown signal is sent, we need to do graceful shutdown out of Node.js and Express to avoid side effects
like finishing active requests before closing server, clean up resources, db connections etc.

see: https://stackfame.com/node-express-graceful-shutdown