### PR TITLE
Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - Upgrade NodeJS version from 10 to 12 in Dockerfile due to Node 10 End-of-Life
 - Set Nodejs 12 as minimum version in packages.json (effectively removing Nodev10 from supported versions)
 - FIX: Add graceful shutdown listening to SIGINT (#115)
+- Upgrade logops dep from 2.1.0 to 2.1.2 due to colors dependency corruption

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "command-node": "0.1.1",
     "request": "2.88.0",
     "async": "1.5.2",
-    "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
+    "iotagent-node-lib": "https://github.com/telefonicaid/iotagent-node-lib.git#master",
     "express": "4.16.4",
     "body-parser": "1.18.3",
     "logops": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "iotagent-node-lib": "git://github.com/telefonicaid/iotagent-node-lib.git#master",
     "express": "4.16.4",
     "body-parser": "1.18.3",
-    "logops": "2.1.0"
+    "logops": "2.1.2"
   },
   "devDependencies": {
     "chai": "~4.2.0",


### PR DESCRIPTION
logops < 2.1.2 depends on colors dependency, which recently have a corruption problem: https://snyk.io/blog/open-source-npm-packages-colors-faker/
